### PR TITLE
Get rid of mpris-qt5 dependency

### DIFF
--- a/rpm/org.ilyavysotsky.yasailmusic.yaml
+++ b/rpm/org.ilyavysotsky.yasailmusic.yaml
@@ -19,7 +19,6 @@ PkgConfigBR:
 
 Requires:
   - sailfishsilica-qt5 >= 0.10.9
-  - mpris-qt5 >= 1.0.5
 
 Files:
   - '%{_bindir}'


### PR DESCRIPTION
The app works fine without it (at least it was checked on Aurora v4.0.2.130).
Also, this is necessary, because removing it solves the problem with package
validation.

Relates #1
Closes #8